### PR TITLE
minor change to fix copy item type

### DIFF
--- a/items.go
+++ b/items.go
@@ -51,9 +51,9 @@ func addItemDetails(item Item, previousSearch string, autoFetchCache bool) {
 	}
 	wf.NewItem("Type").
 		Subtitle(fmt.Sprintf("%s (%d)", typeName(item.Type), item.Type)).
-		Arg(fmt.Sprint(item.Type)).
+		Arg(fmt.Sprintf("%s (%d)", typeName(item.Type), item.Type)).
 		Icon(iconList).
-		Var("notification", fmt.Sprintf("Copied Item Id:\n%q", item.Id)).
+		Var("notification", fmt.Sprintf("Copied Item Type:\n%s (%d)", typeName(item.Type), item.Type)).
 		Var("action", "output").Valid(true)
 	if (conf.EmptyDetailResults && item.Type != 2) || (item.Type != 2 && item.Notes != "") {
 		wf.NewItem("Note").


### PR DESCRIPTION
Choosing **Copy Type** currently shows "Copied Item Id..." in the notification. This change corrects this and also copies the `typeName` along with the numeric, in the same way that it's displayed by the workflow.