### PR TITLE
set permissions to binary before executing it

### DIFF
--- a/workflow/info.plist
+++ b/workflow/info.plist
@@ -457,7 +457,7 @@
 				<key>runningsubtext</key>
 				<string>Loading auth configs…</string>
 				<key>script</key>
-				<string>./bitwarden-alfred-workflow -auth -- "$1"</string>
+				<string>/bin/chmod +x bitwarden-alfred-workflow; ./bitwarden-alfred-workflow -auth -- "$1"</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>
@@ -523,7 +523,7 @@
 				<key>runningsubtext</key>
 				<string></string>
 				<key>script</key>
-				<string>./bitwarden-alfred-workflow $action $action2 $action3 $1</string>
+				<string>/bin/chmod +x bitwarden-alfred-workflow; ./bitwarden-alfred-workflow $action $action2 $action3 $1</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>
@@ -552,7 +552,7 @@
 				<key>escaping</key>
 				<integer>102</integer>
 				<key>script</key>
-				<string>./bitwarden-alfred-workflow $action $action2 $action3 $1</string>
+				<string>/bin/chmod +x bitwarden-alfred-workflow; ./bitwarden-alfred-workflow $action $action2 $action3 $1</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>
@@ -745,7 +745,7 @@
 				<key>runningsubtext</key>
 				<string>Finding secrets…</string>
 				<key>script</key>
-				<string>./bitwarden-alfred-workflow $1</string>
+				<string>/bin/chmod +x bitwarden-alfred-workflow; ./bitwarden-alfred-workflow $1</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>
@@ -819,7 +819,7 @@
 				<key>runningsubtext</key>
 				<string>Finding secrets in folders…</string>
 				<key>script</key>
-				<string>./bitwarden-alfred-workflow --folder $action $action2 $action3 $1
+				<string>/bin/chmod +x bitwarden-alfred-workflow; ./bitwarden-alfred-workflow --folder $action $action2 $action3 $1
 </string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
@@ -948,7 +948,7 @@
 				<key>runningsubtext</key>
 				<string>Reading settings…</string>
 				<key>script</key>
-				<string>./bitwarden-alfred-workflow -conf "$1"</string>
+				<string>/bin/chmod +x bitwarden-alfred-workflow; ./bitwarden-alfred-workflow -conf "$1"</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>
@@ -977,7 +977,7 @@
 				<key>escaping</key>
 				<integer>102</integer>
 				<key>script</key>
-				<string>./bitwarden-alfred-workflow $action $action2 $action3 $1</string>
+				<string>/bin/chmod +x bitwarden-alfred-workflow; ./bitwarden-alfred-workflow $action $action2 $action3 $1</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>
@@ -1081,7 +1081,7 @@
 				<key>runningsubtext</key>
 				<string></string>
 				<key>script</key>
-				<string>./bitwarden-alfred-workflow $action $action2 $action3 $1</string>
+				<string>/bin/chmod +x bitwarden-alfred-workflow; ./bitwarden-alfred-workflow $action $action2 $action3 $1</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>


### PR DESCRIPTION
some sync providers like Nextcloud don't sync unix/linux file metadata and the binary is no longer executable after the sync.
setting execute permissions (`/bin/chmod +x`) before running the binary to fix this.
fixes #56 