### PR TITLE
fix: prevent string expansion from altering password

### DIFF
--- a/workflow/bitwarden-auth-flow.js
+++ b/workflow/bitwarden-auth-flow.js
@@ -125,7 +125,7 @@ function login(email, password, totp, totpMode) {
 function unlock(password) {
     var app = Application.currentApplication()
     app.includeStandardAdditions = true
-    var cmd = `PATH=${PATH}; ${BW_EXEC} unlock "${password}" --raw`
+    var cmd = `PATH=${PATH}; ${BW_EXEC} unlock '${password}' --raw`
     try {
         var result = app.doShellScript(cmd);
         var res = setToken(result)


### PR DESCRIPTION
My password had a character in it that cause the command line to change the password as it was passed to the cli. Changing to single quotes fixed it.

Thanks for the awesome project!