### PR TITLE
small changes

### DIFF
--- a/bw_auto_lock.sh
+++ b/bw_auto_lock.sh
@@ -112,11 +112,7 @@ if ! hash "${bwexec}" 2>/dev/null; then
 fi
 export BW_EXEC=${bwexec}
 
-if [ `uname -p` = "i386" ]; then 
-    wf_bin="${wf_dir}/bitwarden-alfred-workflow-amd64"
-else
-    wf_bin="${wf_dir}/bitwarden-alfred-workflow-arm64"
-fi
+wf_bin="${wf_dir}/bitwarden-alfred-workflow"
 
 case $1 in
 	(-i|--install)

--- a/bw_cache_update.sh
+++ b/bw_cache_update.sh
@@ -1,58 +1,68 @@
 #!/bin/bash
 
+_usage() {
+cat <<EOF
+usage: ${0##*/} [-irlv]
+  -i    install_service
+  -r    remove service
+  -l    install_symlink
+  -v    set env vars for debugging
+EOF
+}
+
 _end() {
-	local r m
-	r=$1
-	m="$2"
-	echo "result|$r|$m"
-	exit $r
+  local r m
+  r=$1
+  m="$2"
+  echo "result|$r|$m"
+  exit $r
 }
 
 _generateCalIntervals() {
-	local cnt=0
-	local _timedef
-	local re='^[0-9]+$'
-	AUTOSYNC_TIMES=$(_get_var_from_plist "${infoplist}" variables.AUTOSYNC_TIMES | /usr/bin/tr ',' '\n')
-	[ -n "$AUTOSYNC_TIMES" ] || _end 1 "AUTOSYNC_TIMES was not defined in workflow variables"
-	#choose StartInterval or StartCalendarInterval mode
-	if [[ $AUTOSYNC_TIMES =~ $re ]]; then
-		SYNC_DESC="every ${AUTOSYNC_TIMES} seconds"
-		/usr/bin/plutil -insert StartInterval -integer "${AUTOSYNC_TIMES}" "${plist_tmp_path}"
-		(( cnt++ ))
-	else
-		SYNC_DESC="at "
-		/usr/bin/plutil -replace StartCalendarInterval -xml '<array/>' "${plist_tmp_path}"
-		while IFS=: read -r AUTO_HOUR AUTO_MIN; do
-			_timedef="${AUTO_HOUR}:${AUTO_MIN}"
-			if ! [[ $AUTO_HOUR =~ $re ]]; then
-				echo "error: HOUR must be a number; skipping [${_timedef}]" 1>&2
-				continue
-			fi
-			if ! [[ $AUTO_MIN =~ $re ]]; then
-				echo "error: MIN must be a number; skipping [${_timedef}]" 1>&2
-				continue
-			fi
-			if [ "$AUTO_HOUR" -lt 0 ] || [ "$AUTO_HOUR" -gt 23 ]; then
-				echo "error: HOUR must be between 0-23; skipping [${_timedef}]"
-				continue
-			fi
-			if [ "$AUTO_MIN" -lt 0 ] || [ "$AUTO_MIN" -gt 59 ]; then
-				echo "error: MIN must be between 0-59; skipping [${_timedef}]"
-				continue
-			fi
-			/usr/bin/plutil -insert StartCalendarInterval.${cnt} -xml '<dict/>' "${plist_tmp_path}"
-			/usr/bin/plutil -insert StartCalendarInterval.${cnt}.Hour -integer "${AUTO_HOUR}" "${plist_tmp_path}"
-			/usr/bin/plutil -insert StartCalendarInterval.${cnt}.Minute -integer "${AUTO_MIN}" "${plist_tmp_path}"
-			(( cnt++ ))
-			SYNC_DESC+="${_timedef} "
-		done <<<"${AUTOSYNC_TIMES}"
-	fi
-	if [ "$cnt" -gt 0 ]; then
-		echo "generated config with ${cnt} timers [${SYNC_DESC}]"
-		return 0
-	else
-		return 1
-	fi
+  local cnt=0
+  local _timedef
+  local re='^[0-9]+$'
+  AUTOSYNC_TIMES=$(_get_var_from_plist "${infoplist}" variables.AUTOSYNC_TIMES | /usr/bin/tr ',' '\n')
+  [ -n "$AUTOSYNC_TIMES" ] || _end 1 "AUTOSYNC_TIMES was not defined in workflow variables"
+  #choose StartInterval or StartCalendarInterval mode
+  if [[ $AUTOSYNC_TIMES =~ $re ]]; then
+    SYNC_DESC="every ${AUTOSYNC_TIMES} seconds"
+    /usr/bin/plutil -insert StartInterval -integer "${AUTOSYNC_TIMES}" "${plist_tmp_path}"
+    (( cnt++ ))
+  else
+    SYNC_DESC="at "
+    /usr/bin/plutil -replace StartCalendarInterval -xml '<array/>' "${plist_tmp_path}"
+    while IFS=: read -r AUTO_HOUR AUTO_MIN; do
+      _timedef="${AUTO_HOUR}:${AUTO_MIN}"
+      if ! [[ $AUTO_HOUR =~ $re ]]; then
+        echo "error: HOUR must be a number; skipping [${_timedef}]" 1>&2
+        continue
+      fi
+      if ! [[ $AUTO_MIN =~ $re ]]; then
+        echo "error: MIN must be a number; skipping [${_timedef}]" 1>&2
+        continue
+      fi
+      if [ "$AUTO_HOUR" -lt 0 ] || [ "$AUTO_HOUR" -gt 23 ]; then
+        echo "error: HOUR must be between 0-23; skipping [${_timedef}]"
+        continue
+      fi
+      if [ "$AUTO_MIN" -lt 0 ] || [ "$AUTO_MIN" -gt 59 ]; then
+        echo "error: MIN must be between 0-59; skipping [${_timedef}]"
+        continue
+      fi
+      /usr/bin/plutil -insert StartCalendarInterval.${cnt} -xml '<dict/>' "${plist_tmp_path}"
+      /usr/bin/plutil -insert StartCalendarInterval.${cnt}.Hour -integer "${AUTO_HOUR}" "${plist_tmp_path}"
+      /usr/bin/plutil -insert StartCalendarInterval.${cnt}.Minute -integer "${AUTO_MIN}" "${plist_tmp_path}"
+      (( cnt++ ))
+      SYNC_DESC+="${_timedef} "
+    done <<<"${AUTOSYNC_TIMES}"
+  fi
+  if [ "$cnt" -gt 0 ]; then
+    echo "generated config with ${cnt} timers [${SYNC_DESC}]"
+    return 0
+  else
+    return 1
+  fi
 }
 
 _createPlist() {
@@ -61,135 +71,146 @@ _createPlist() {
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Label</key>
-	<string>$launchd_name</string>
-	<key>ProgramArguments</key>
-	<array>
-		<string>/bin/bash</string>
-		<string>--</string>
-		<string>$wf_dir/${0##*/}</string>
-	</array>
-	<key>StandardErrorPath</key>
-	<string>/tmp/$launchd_name.err</string>
-	<key>StandardOutPath</key>
-	<string>/tmp/$launchd_name.out</string>
+  <key>Label</key>
+  <string>$launchd_name</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>--</string>
+    <string>$wf_dir/${0##*/}</string>
+  </array>
+  <key>StandardErrorPath</key>
+  <string>/tmp/$launchd_name.err</string>
+  <key>StandardOutPath</key>
+  <string>/tmp/$launchd_name.out</string>
 </dict>
 </plist>
 EOF
 }
 
 _install_service() {
-	_remove_service
-	echo "generating new service configuration"
-	_createPlist
-	if ! _generateCalIntervals; then _end 1 "invalid timer configuration"; fi
-	if ! /usr/bin/plutil -lint "${plist_tmp_path}"; then _end 1 "did not generate a valid plist"; fi
-	if ! /bin/cp -f "${plist_tmp_path}" "${plist_path}"; then _end 1 "failed to copy LaunchAgent"; fi
-	echo "loading service"
-	/bin/launchctl bootstrap gui/$(id -u) "${plist_path}"
-	if [ $? -eq 0 ]; then
-		_end 0 "Service has been installed; sync will run ${SYNC_DESC}"
-	else
-		_end 1 "Could not install service, check logfiles for detail"
-	fi
+  _remove_service
+  echo "generating new service configuration"
+  _createPlist
+  if ! _generateCalIntervals; then _end 1 "invalid timer configuration"; fi
+  if ! /usr/bin/plutil -lint "${plist_tmp_path}"; then _end 1 "did not generate a valid plist"; fi
+  if ! /bin/cp -f "${plist_tmp_path}" "${plist_path}"; then _end 1 "failed to copy LaunchAgent"; fi
+  echo "loading service"
+  /bin/launchctl bootstrap gui/$UID "${plist_path}"
+  if [ $? -eq 0 ]; then
+    _end 0 "Service has been installed; sync will run ${SYNC_DESC}"
+  else
+    _end 1 "Could not install service, check logfiles for detail"
+  fi
 }
 
 _remove_service() {
-	echo "removing existing service"
-	/bin/launchctl bootout gui/$(id -u) "${plist_path}" 2>/dev/null
-	/bin/rm "${plist_path}" 2>/dev/null
-	if [ -e "${plist_path}" ]; then
-		_end 1 "Could not delete existing LaunchAgent"
-	else
-		return 0
-	fi
+  echo "removing existing service"
+  /bin/launchctl bootout gui/$UID "${plist_path}" 2>/dev/null
+  /bin/rm "${plist_path}" 2>/dev/null
+  if [ -e "${plist_path}" ]; then
+    _end 1 "Could not delete existing LaunchAgent"
+  else
+    return 0
+  fi
 }
 
 _install_symlink() {
-	AUTOSYNC_SCRIPT_DIR=$(_get_var_from_plist "${infoplist}" variables.AUTOSYNC_SCRIPT_DIR)
-	[ -n "${AUTOSYNC_SCRIPT_DIR}" ] || AUTOSYNC_SCRIPT_DIR=/usr/local/bin
-	if /bin/ln -sfv "$wf_dir/${0##*/}" "${AUTOSYNC_SCRIPT_DIR}"; then
-		_end 0 "Symlink created in ${AUTOSYNC_SCRIPT_DIR}"
-	else
-		_end 1 "Symlink could not be created in ${AUTOSYNC_SCRIPT_DIR}"
-	fi
+  AUTOSYNC_SCRIPT_DIR=$(_get_var_from_plist "${infoplist}" variables.AUTOSYNC_SCRIPT_DIR)
+  [ -n "${AUTOSYNC_SCRIPT_DIR}" ] || AUTOSYNC_SCRIPT_DIR=/usr/local/bin
+  if /bin/ln -sfv "$wf_dir/${0##*/}" "${AUTOSYNC_SCRIPT_DIR}"; then
+    _end 0 "Symlink created in ${AUTOSYNC_SCRIPT_DIR}"
+  else
+    _end 1 "Symlink could not be created in ${AUTOSYNC_SCRIPT_DIR}"
+  fi
 }
 
 _get_var_from_plist() {
-	# 1=filename, 2=key
-	[ -n "$2" ] || return 1
-	[ -e "$1" ] || return 1
-	/usr/bin/plutil -extract "$2" xml1 -o - -- "$1" |
-	/usr/bin/sed -n "s/.*<string>\(.*\)<\/string>.*/\1/p"
+  # 1=filename, 2=key
+  [ -n "$2" ] || return 1
+  [ -e "$1" ] || return 1
+  /usr/bin/plutil -extract "$2" xml1 -o - -- "$1" |
+  /usr/bin/sed -n "s/.*<string>\(.*\)<\/string>.*/\1/p"
 }
 
 # find TMP dir
 if [ -z "${TMPDIR}" ]; then
-	TMPDIR=$(/usr/bin/getconf DARWIN_USER_TEMP_DIR)
-	if [ ! -e "${TMPDIR}" ]; then
-		_end 1 "could not find TMPDIR directory"
-	fi
+  TMPDIR=$(/usr/bin/getconf DARWIN_USER_TEMP_DIR)
+  if [ ! -e "${TMPDIR}" ]; then
+    _end 1 "could not find TMPDIR directory"
+  fi
 fi
 
-prefs="$HOME/Library/Application Support/Alfred/prefs.json"
-[ -e "${prefs}" ] || _end 1 "can't find Alfred prefs"
-wf_basedir=$(_get_var_from_plist "${prefs}" current)/workflows
-[ -e "${wf_basedir}" ] || _end 1 "can't find Alfred workflow dir"
+_setEnvVars() {
+  prefs="$HOME/Library/Application Support/Alfred/prefs.json"
+  [ -e "${prefs}" ] || _end 1 "can't find Alfred prefs"
+  wf_basedir=$(_get_var_from_plist "${prefs}" current)/workflows
+  #wf_basedir=$(_get_var_from_plist "$HOME/Library/Preferences/com.runningwithcrayons.Alfred-Preferences.plist" syncfolder)
+  [ -e "${wf_basedir}" ] || _end 1 "can't find Alfred workflow dir"
 
-alfred_app_bundleid=com.runningwithcrayons.Alfred
-alfred_workflow_bundleid=com.lisowski-development.alfred.bitwarden
-alfred_workflow_cache="$HOME/Library/Caches/${alfred_app_bundleid}/Workflow Data/${alfred_workflow_bundleid}"
-alfred_workflow_data="$HOME/Library/Application Support/Alfred/Workflow Data/${alfred_workflow_bundleid}"
-launchd_name=${alfred_workflow_bundleid}_autosync
-plist_path="$HOME/Library/LaunchAgents/${launchd_name}.plist"
-plist_tmp_path="$TMPDIR/${launchd_name}.plist"
+  alfred_app_bundleid='com.runningwithcrayons.Alfred'
+  alfred_workflow_bundleid='com.lisowski-development.alfred.bitwarden'
+  alfred_workflow_cache="$HOME/Library/Caches/${alfred_app_bundleid}/Workflow Data/${alfred_workflow_bundleid}"
+  alfred_workflow_data="$HOME/Library/Application Support/Alfred/Workflow Data/${alfred_workflow_bundleid}"
+  launchd_name=${alfred_workflow_bundleid}_autosync
+  plist_path="$HOME/Library/LaunchAgents/${launchd_name}.plist"
+  plist_tmp_path="$TMPDIR/${launchd_name}.plist"
 
-#wf_basedir=$(_get_var_from_plist "$HOME/Library/Preferences/com.runningwithcrayons.Alfred-Preferences.plist" syncfolder)
-infoplist=$(/usr/bin/find "${wf_basedir}" -name info.plist -depth 2 -exec /usr/bin/grep -H "<string>${alfred_workflow_bundleid}</string>" {} \; | /usr/bin/awk -F: '{ print $1 }')
-[ -e "${infoplist}" ] || _end 1 "can't find Bitwarden v2 workflow"
-wf_dir=${infoplist%/*}
-if [ `uname -p` = "i386" ]; then 
-    wf_bin="${wf_dir}/bitwarden-alfred-workflow-amd64"
-else
-    wf_bin="${wf_dir}/bitwarden-alfred-workflow-arm64"
-fi
-alfred_workflow_version=$(_get_var_from_plist "${infoplist}" version)
-[ -n "${alfred_workflow_version}" ] || _end 1 "can't determine workflow version"
-echo "found workflow v${alfred_workflow_version} at ${wf_dir}" 1>&2
-bwpath=$(_get_var_from_plist "${infoplist}" variables.PATH)
-[ -n "${bwpath}" ] || _end 1 "PATH variable not set in workflow"
-bwexec=$(_get_var_from_plist "${infoplist}" variables.BW_EXEC)
-bwauth_keyword=$(_get_var_from_plist "${infoplist}" variables.bwauth_keyword)
+  infoplist=$(/usr/bin/find -L "${wf_basedir}" -name info.plist -depth 2 -exec /usr/bin/grep -H "<string>${alfred_workflow_bundleid}</string>" {} \; | /usr/bin/awk -F: '{ print $1 }')
+  [ -e "${infoplist}" ] || _end 1 "can't find Bitwarden v2 workflow"
+  wf_dir=${infoplist%/*}
+  wf_bin="${wf_dir}/bitwarden-alfred-workflow"
+  alfred_workflow_version=$(_get_var_from_plist "${infoplist}" version)
+  [ -n "${alfred_workflow_version}" ] || _end 1 "can't determine workflow version"
+  echo "found workflow v${alfred_workflow_version} at ${wf_dir}" 1>&2
+  WF_PATH=$(_get_var_from_plist "${infoplist}" variables.PATH)
+  [ -n "${WF_PATH}" ] || _end 1 "PATH variable not set in workflow"
+  BW_EXEC=$(_get_var_from_plist "${infoplist}" variables.BW_EXEC)
+  bwauth_keyword=$(_get_var_from_plist "${infoplist}" variables.bwauth_keyword)
 
-export alfred_workflow_bundleid
-export alfred_workflow_cache
-export alfred_workflow_data
-export alfred_workflow_version
-export bwauth_keyword
-export PATH=${bwpath}
-export BW_EXEC=${bwexec}
+  export alfred_workflow_bundleid
+  export alfred_workflow_cache
+  export alfred_workflow_data
+  export alfred_workflow_version
+  export bwauth_keyword
+  export PATH=${WF_PATH}
+  export BW_EXEC
+  export DEBUG
+}
 
 case $1 in
-	(-i|--install)
-		_install_service
-		exit
-		;;
-	(-r|--remove)
-		_remove_service
-		[ $? -eq 0 ] && _end 0 "Autosync service has been removed"
-		exit
-		;;
-	(-l|--link)
-		_install_symlink
-		exit
-		;;
+  -h|--help) _usage; exit;;
 esac
 
-if ! hash "${bwexec}" 2>/dev/null; then
-	_end 1 "bw command not found, check PATH env variable"
+_setEnvVars
+
+case $1 in
+  -i|--install)
+    _install_service
+    exit
+    ;;
+  -r|--remove)
+    if _remove_service; then
+      _end 0 "Autosync service has been removed"
+    fi
+    exit
+    ;;
+  -l|--link)
+    _install_symlink
+    exit
+    ;;
+  -v|--setenv)
+    if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+      echo "You must source the script when using this option: \`. ${0##*/} -v\`"
+      exit 1
+    fi
+    return
+    ;;
+esac
+
+if ! hash "${BW_EXEC}" 2>/dev/null; then
+  _end 1 "bw command not found, check PATH and BW_EXEC env variables"
 fi
 
-/usr/bin/xattr -d com.apple.quarantine "$wf_bin" 2>/dev/null
+"${wf_dir}/fix_flags.sh"
 "$wf_bin" -sync -force
-#"$wf_bin" -cache
-#"$wf_bin" -icons

--- a/fix_flags.sh
+++ b/fix_flags.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd "$(dirname "$0")" || exit 1
+/usr/bin/xattr -d com.apple.quarantine bitwarden-alfred-workflow 2>/dev/null
+/bin/chmod +x bitwarden-alfred-workflow 2>/dev/null

--- a/workflow/info.plist
+++ b/workflow/info.plist
@@ -667,7 +667,7 @@
 				<key>runningsubtext</key>
 				<string>Loading auth configs…</string>
 				<key>script</key>
-				<string>/bin/chmod +x bitwarden-alfred-workflow-*; if [ "$(arch)" = "i386" ] ; then ./bitwarden-alfred-workflow-amd64 -auth -- "$1"; else ./bitwarden-alfred-workflow-arm64 -auth -- "$1"; fi</string>
+				<string>./fix_flags.sh; ./bitwarden-alfred-workflow -auth -- "$1"</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>
@@ -714,7 +714,7 @@
 				<key>runningsubtext</key>
 				<string></string>
 				<key>script</key>
-				<string>/bin/chmod +x bitwarden-alfred-workflow-*; if [ "$(arch)" = "i386" ] ; then ./bitwarden-alfred-workflow-amd64 $action $action2 $action3 $1; else ./bitwarden-alfred-workflow-arm64 $action $action2 $action3 $1; fi</string>
+				<string>./fix_flags.sh; ./bitwarden-alfred-workflow $action $action2 $action3 $1</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>
@@ -762,7 +762,7 @@
 				<key>escaping</key>
 				<integer>102</integer>
 				<key>script</key>
-				<string>/bin/chmod +x bitwarden-alfred-workflow-*; if [ "$(arch)" = "i386" ] ; then ./bitwarden-alfred-workflow-amd64 $action $action2 $action3 $1; else ./bitwarden-alfred-workflow-arm64 $action $action2 $action3 $1; fi</string>
+				<string>./fix_flags.sh; ./bitwarden-alfred-workflow $action $action2 $action3 $1</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>
@@ -924,7 +924,7 @@
 				<key>runningsubtext</key>
 				<string>Finding secrets…</string>
 				<key>script</key>
-				<string>/bin/chmod +x bitwarden-alfred-workflow-*; if [ "$(arch)" = "i386" ] ; then ./bitwarden-alfred-workflow-amd64 $1; else ./bitwarden-alfred-workflow-arm64 $1; fi</string>
+				<string>./fix_flags.sh; ./bitwarden-alfred-workflow $1</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>
@@ -1029,8 +1029,7 @@
 				<key>runningsubtext</key>
 				<string>Finding secrets in folders…</string>
 				<key>script</key>
-				<string>/bin/chmod +x bitwarden-alfred-workflow-*; if [ "$(arch)" = "i386" ] ; then ./bitwarden-alfred-workflow-amd64 --folder $action $action2 $action3 $1; else ./bitwarden-alfred-workflow-arm64 --folder $action $action2 $action3 $1; fi
-</string>
+				<string>./fix_flags.sh; ./bitwarden-alfred-workflow --folder $action $action2 $action3 $1</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>
@@ -1158,7 +1157,7 @@
 				<key>runningsubtext</key>
 				<string>Reading settings…</string>
 				<key>script</key>
-				<string>/bin/chmod +x bitwarden-alfred-workflow-*; if [ "$(arch)" = "i386" ] ; then ./bitwarden-alfred-workflow-amd64 -conf "$1"; else ./bitwarden-alfred-workflow-arm64 -conf "$1"; fi</string>
+				<string>./fix_flags.sh; ./bitwarden-alfred-workflow -conf "$1"</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>
@@ -1206,7 +1205,7 @@
 				<key>escaping</key>
 				<integer>102</integer>
 				<key>script</key>
-				<string>/bin/chmod +x bitwarden-alfred-workflow-*; if [ "$(arch)" = "i386" ] ; then ./bitwarden-alfred-workflow-amd64 $action $action2 $action3 $1; else ./bitwarden-alfred-workflow-arm64 $action $action2 $action3 $1; fi</string>
+				<string>./fix_flags.sh; ./bitwarden-alfred-workflow $action $action2 $action3 $1</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>
@@ -1270,7 +1269,7 @@
 				<key>runningsubtext</key>
 				<string></string>
 				<key>script</key>
-				<string>/bin/chmod +x bitwarden-alfred-workflow-*; if [ "$(arch)" = "i386" ] ; then ./bitwarden-alfred-workflow-amd64 $action $action2 $action3 $1; else ./bitwarden-alfred-workflow-arm64 $action $action2 $action3 $1; fi</string>
+				<string>./fix_flags.sh; ./bitwarden-alfred-workflow $action $action2 $action3 $1</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>


### PR DESCRIPTION
> **n.b.** _I switched from tabs to spaces since last time, so the changes below look larger than they actually are. Append `?w=1` param to the diff url to ignore that whitespace... e.g. [d35323d](https://github.com/luckman212/bitwarden-alfred-workflow/commit/d35323df630a926f8dbe2bddc80cb40cb36aeaa0?branch=d35323df630a926f8dbe2bddc80cb40cb36aeaa0&diff=split&w=1)_

### small update

- add `fix_flags.sh` helper to remove quarantine and set +x bit instead of repeating that in every script action
- remove dependency on `$(arch)` tests -- refer instead to universal binary. @blacs30 build with:
```
lipo -create -output bitwarden-alfred-workflow bitwarden-alfred-workflow-amd64 bitwarden-alfred-workflow-arm64
```
- clean up case syntax, remove unnecessary opening `(`s
- switch to `$UID` instead of forking `$(id -u)` (faster)
- added small usage help text
- add `--setenv` command line option to export the env vars for debugging