### PR TITLE
Feature/sync hide search

### DIFF
--- a/src/bitwarden.go
+++ b/src/bitwarden.go
@@ -106,6 +106,13 @@ func runSync(force bool, last bool) {
 
 		// Creating the items cache
 		runCache()
+
+		// If we ran the sync via the daemon
+		// don't open the search
+		backgroundSyncDaemon := os.Getenv("BACKGROUND_SYNC_DAEMON")
+		if backgroundSyncDaemon == "true" {
+			return
+		}
 		searchAlfred(conf.BwKeyword)
 	}
 }

--- a/workflow/bw_cache_update.sh
+++ b/workflow/bw_cache_update.sh
@@ -176,6 +176,8 @@ _setEnvVars() {
   export PATH=${WF_PATH}
   export BW_EXEC
   export DEBUG
+  # the sync function will not open the Alfred Search window if this is set to true
+  export BACKGROUND_SYNC_DAEMON=true
 }
 
 case $1 in

--- a/workflow/info.plist
+++ b/workflow/info.plist
@@ -2234,7 +2234,7 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 		<string>WEBUI_URL</string>
 	</array>
 	<key>version</key>
-	<string>2.4.5</string>
+	<string>2.4.6</string>
 	<key>webaddress</key>
 	<string>https://github.com/blacs30/bitwarden-alfred-workflow</string>
 </dict>


### PR DESCRIPTION
- background sync sets env var `BACKGROUND_SYNC_DAEMON` to `true`
- Workflow doesn't pop up the Alfred search if the background sync is running

Fixes #138 