### PR TITLE
Migrate env vars to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@
 * many customizations possible
 
 
-> Requires Alfred 4.1 or newer; NOT tested with Alfred 3
+> This workflow requires Alfred 5.0+. 
+> This workflow is undergoing some changes in order to be listed on [Alfred Gallery](alfred.app)
+> If you are using Alfred 4, the latest supported version is 2.4.7. 
+> NOT tested with Alfred 3
 
 ![Bitwarden V2 - Alfred Workflow Demo](./assets/bitwarden-v2.gif)
 

--- a/workflow/info.plist
+++ b/workflow/info.plist
@@ -2142,9 +2142,9 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 			<key>config</key>
 			<dict>
 				<key>default</key>
-				<string>example@provider.com</string>
-				<key>placeholder</key>
 				<string></string>
+				<key>placeholder</key>
+				<string>example@provider.com</string>
 				<key>required</key>
 				<true/>
 				<key>trim</key>

--- a/workflow/info.plist
+++ b/workflow/info.plist
@@ -2452,19 +2452,36 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 			<dict>
 				<key>default</key>
 				<string>0</string>
-				<key>placeholder</key>
-				<string></string>
-				<key>required</key>
-				<false/>
-				<key>trim</key>
-				<true/>
+				<key>pairs</key>
+				<array>
+					<array>
+						<string>Authenticator-app</string>
+						<string>0</string>
+					</array>
+					<array>
+						<string>Email</string>
+						<string>1</string>
+					</array>
+					<array>
+						<string>Duo</string>
+						<string>2</string>
+					</array>
+					<array>
+						<string>Yubikey</string>
+						<string>3</string>
+					</array>
+					<array>
+						<string>U2F</string>
+						<string>4</string>
+					</array>
+				</array>
 			</dict>
 			<key>description</key>
-			<string></string>
+			<string>This option is only used when Enable 2FA is checked</string>
 			<key>label</key>
 			<string>2FA Mode</string>
 			<key>type</key>
-			<string>textfield</string>
+			<string>popupbutton</string>
 			<key>variable</key>
 			<string>2FA_MODE</string>
 		</dict>

--- a/workflow/info.plist
+++ b/workflow/info.plist
@@ -1572,6 +1572,8 @@
 			<dict>
 				<key>delimiter</key>
 				<string>|</string>
+				<key>discardemptyarguments</key>
+				<false/>
 				<key>outputas</key>
 				<integer>0</integer>
 				<key>trimarguments</key>
@@ -1775,6 +1777,8 @@
 			<dict>
 				<key>delimiter</key>
 				<string>|</string>
+				<key>discardemptyarguments</key>
+				<false/>
 				<key>outputas</key>
 				<integer>0</integer>
 				<key>trimarguments</key>
@@ -2133,13 +2137,340 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 		</dict>
 	</dict>
 	<key>userconfigurationconfig</key>
-	<array/>
+	<array>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string>example@provider.com</string>
+				<key>placeholder</key>
+				<string></string>
+				<key>required</key>
+				<true/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string>This is the email you use to log into Bitwarden</string>
+			<key>label</key>
+			<string>bitwarden login email</string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>EMAIL</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string>.bw</string>
+				<key>placeholder</key>
+				<string></string>
+				<key>required</key>
+				<false/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string>This is the keyword you use to trigger workflow</string>
+			<key>label</key>
+			<string>Alfred Trigger Keyword</string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>bw_keyword</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string>.bwauth</string>
+				<key>placeholder</key>
+				<string></string>
+				<key>required</key>
+				<false/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string>This is the keyword to open authentication settings</string>
+			<key>label</key>
+			<string>Authentication Setup Menu Keyword</string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>bwauth_keyword</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string>.bwf</string>
+				<key>placeholder</key>
+				<string></string>
+				<key>required</key>
+				<false/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string>Open your bitwarden vault in folder view</string>
+			<key>label</key>
+			<string>Folder View Keyword</string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>bwf_keyword</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string>.bwconfig</string>
+				<key>placeholder</key>
+				<string></string>
+				<key>required</key>
+				<false/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string></string>
+			<key>label</key>
+			<string>Config Menu Keyword</string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>bwconf_keyword</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string>.bwauto</string>
+				<key>placeholder</key>
+				<string></string>
+				<key>required</key>
+				<false/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string></string>
+			<key>label</key>
+			<string>Automatic Sync Service Keyword</string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>bwauto_keyword</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string>.bwautolock</string>
+				<key>placeholder</key>
+				<string></string>
+				<key>required</key>
+				<false/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string></string>
+			<key>label</key>
+			<string>Automatic Lock Service Keyword</string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>bwautolock_keyword</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string>/usr/bin:/usr/local/bin:/usr/local/sbin:/usr/local/share/npm/bin:/usr/bin:/usr/sbin:/opt/homebrew/bin</string>
+				<key>placeholder</key>
+				<string>default path</string>
+				<key>required</key>
+				<false/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string></string>
+			<key>label</key>
+			<string>Bitwarden CLI Path</string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>PATH</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<false/>
+				<key>required</key>
+				<false/>
+				<key>text</key>
+				<string></string>
+			</dict>
+			<key>description</key>
+			<string></string>
+			<key>label</key>
+			<string>Enable Debug Mode (for developers)</string>
+			<key>type</key>
+			<string>checkbox</string>
+			<key>variable</key>
+			<string>DEBUG</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<false/>
+				<key>required</key>
+				<false/>
+				<key>text</key>
+				<string></string>
+			</dict>
+			<key>description</key>
+			<string></string>
+			<key>label</key>
+			<string>use API key</string>
+			<key>type</key>
+			<string>checkbox</string>
+			<key>variable</key>
+			<string>USE_APIKEY</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string>1440</string>
+				<key>placeholder</key>
+				<string>int</string>
+				<key>required</key>
+				<false/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string></string>
+			<key>label</key>
+			<string>auto lock timeout (s)</string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>LOCK_TIMEOUT</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string></string>
+				<key>placeholder</key>
+				<string></string>
+				<key>required</key>
+				<false/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string></string>
+			<key>label</key>
+			<string>self host url (if you are using official bitwarden, ignore this)</string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>SERVER_URL</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string>https://vault.bitwarden.com</string>
+				<key>placeholder</key>
+				<string></string>
+				<key>required</key>
+				<false/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string></string>
+			<key>label</key>
+			<string>web UI url</string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>WEBUI_URL</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string>10080</string>
+				<key>placeholder</key>
+				<string></string>
+				<key>required</key>
+				<false/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string></string>
+			<key>label</key>
+			<string>Sync Cache Age</string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>SYNC_CACHE_AGE</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<false/>
+				<key>required</key>
+				<false/>
+				<key>text</key>
+				<string></string>
+			</dict>
+			<key>description</key>
+			<string></string>
+			<key>label</key>
+			<string>Enable 2FA</string>
+			<key>type</key>
+			<string>checkbox</string>
+			<key>variable</key>
+			<string>2FA_ENABLED</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string>0</string>
+				<key>placeholder</key>
+				<string></string>
+				<key>required</key>
+				<false/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string></string>
+			<key>label</key>
+			<string>2FA Mode</string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>2FA_MODE</string>
+		</dict>
+	</array>
 	<key>variables</key>
 	<dict>
-		<key>2FA_ENABLED</key>
-		<string>true</string>
-		<key>2FA_MODE</key>
-		<string>0</string>
 		<key>AUTOSYNC_SCRIPT_DIR</key>
 		<string>/usr/local/bin</string>
 		<key>AUTOSYNC_TIMES</key>
@@ -2154,10 +2485,6 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 		<string></string>
 		<key>BW_EXEC</key>
 		<string>bw</string>
-		<key>DEBUG</key>
-		<string>false</string>
-		<key>EMAIL</key>
-		<string></string>
 		<key>EMAIL_MAX_WAIT</key>
 		<string>15</string>
 		<key>EMPTY_DETAIL_RESULTS</key>
@@ -2166,8 +2493,6 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 		<string>43200</string>
 		<key>ICON_CACHE_ENABLED</key>
 		<string>true</string>
-		<key>LOCK_TIMEOUT</key>
-		<string>1440</string>
 		<key>MAX_RESULTS</key>
 		<string>1000</string>
 		<key>MODIFIER_1</key>
@@ -2186,7 +2511,7 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 		<string>cmd,opt</string>
 		<key>MODIFIER_4_ACTION</key>
 		<string>more</string>
-    <key>MODIFIER_5</key>
+		<key>MODIFIER_5</key>
 		<string>cmd,shift</string>
 		<key>MODIFIER_5_ACTION</key>
 		<string>webui</string>
@@ -2196,45 +2521,17 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 		<string>true</string>
 		<key>OUTPUT_FOLDER</key>
 		<string></string>
-		<key>PATH</key>
-		<string>/usr/bin:/usr/local/bin:/usr/local/sbin:/usr/local/share/npm/bin:/usr/bin:/usr/sbin</string>
 		<key>REORDERING_DISABLED</key>
 		<string>true</string>
-		<key>SERVER_URL</key>
-		<string></string>
 		<key>SKIP_TYPES</key>
 		<string></string>
-		<key>SYNC_CACHE_AGE</key>
-		<string>10080</string>
 		<key>TITLE_WITH_URLS</key>
 		<string>false</string>
 		<key>TITLE_WITH_USER</key>
 		<string>true</string>
-		<key>USE_APIKEY</key>
-		<string>false</string>
-    <key>WEBUI_URL</key>
-		<string>https://vault.bitwarden.com</string>
-		<key>bw_keyword</key>
-		<string>.bw</string>
-		<key>bwauth_keyword</key>
-		<string>.bwauth</string>
-		<key>bwauto_keyword</key>
-		<string>.bwauto</string>
-		<key>bwautolock_keyword</key>
-		<string>.bwautolock</string>
-		<key>bwconf_keyword</key>
-		<string>.bwconfig</string>
-		<key>bwf_keyword</key>
-		<string>.bwf</string>
 	</dict>
-	<key>variablesdontexport</key>
-	<array>
-		<string>EMAIL</string>
-		<string>SERVER_URL</string>
-		<string>WEBUI_URL</string>
-	</array>
 	<key>version</key>
-	<string>2.4.7</string>
+	<string>3.0.0</string>
 	<key>webaddress</key>
 	<string>https://github.com/blacs30/bitwarden-alfred-workflow</string>
 </dict>

--- a/workflow/info.plist
+++ b/workflow/info.plist
@@ -2146,12 +2146,12 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 				<key>placeholder</key>
 				<string>example@provider.com</string>
 				<key>required</key>
-				<true/>
+				<false/>
 				<key>trim</key>
 				<true/>
 			</dict>
 			<key>description</key>
-			<string>This is the email you use to log into Bitwarden</string>
+			<string>the email which to use for the login via the Bitwarden CLI, will be read from the data.json of the Bitwarden CLI if present</string>
 			<key>label</key>
 			<string>bitwarden login email</string>
 			<key>type</key>
@@ -2172,34 +2172,13 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 				<true/>
 			</dict>
 			<key>description</key>
-			<string>This is the keyword you use to trigger workflow</string>
+			<string>defines the keyword which opens the Bitwarden Alfred Workflow</string>
 			<key>label</key>
-			<string>Alfred Trigger Keyword</string>
+			<string>Search Keyword</string>
 			<key>type</key>
 			<string>textfield</string>
 			<key>variable</key>
 			<string>bw_keyword</string>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>default</key>
-				<string>.bwauth</string>
-				<key>placeholder</key>
-				<string></string>
-				<key>required</key>
-				<false/>
-				<key>trim</key>
-				<true/>
-			</dict>
-			<key>description</key>
-			<string>This is the keyword to open authentication settings</string>
-			<key>label</key>
-			<string>Authentication Setup Menu Keyword</string>
-			<key>type</key>
-			<string>textfield</string>
-			<key>variable</key>
-			<string>bwauth_keyword</string>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -2214,13 +2193,34 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 				<true/>
 			</dict>
 			<key>description</key>
-			<string>Open your bitwarden vault in folder view</string>
+			<string>defines the keyword which opens the folder search of the Bitwarden Alfred Workflow</string>
 			<key>label</key>
-			<string>Folder View Keyword</string>
+			<string>Folder Search Keyword</string>
 			<key>type</key>
 			<string>textfield</string>
 			<key>variable</key>
 			<string>bwf_keyword</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string>.bwauth</string>
+				<key>placeholder</key>
+				<string></string>
+				<key>required</key>
+				<false/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string>defines the keyword which opens the Bitwarden authentications of the Alfred Workflow</string>
+			<key>label</key>
+			<string>Authentication Setup Keyword</string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>bwauth_keyword</string>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -2235,7 +2235,7 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 				<true/>
 			</dict>
 			<key>description</key>
-			<string></string>
+			<string>defines the keyword which opens the Bitwarden configuration/settings of the Alfred Workflow</string>
 			<key>label</key>
 			<string>Config Menu Keyword</string>
 			<key>type</key>
@@ -2256,7 +2256,7 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 				<true/>
 			</dict>
 			<key>description</key>
-			<string></string>
+			<string>defines the keyword which opens the Bitwarden background sync agent</string>
 			<key>label</key>
 			<string>Automatic Sync Service Keyword</string>
 			<key>type</key>
@@ -2277,7 +2277,7 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 				<true/>
 			</dict>
 			<key>description</key>
-			<string></string>
+			<string>defines the keyword which opens the Bitwarden background lock agent</string>
 			<key>label</key>
 			<string>Automatic Lock Service Keyword</string>
 			<key>type</key>
@@ -2298,7 +2298,7 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 				<true/>
 			</dict>
 			<key>description</key>
-			<string></string>
+			<string>The PATH env variable which is used to search for executables (like the Bitwarden CLI configured with BW_EXEC, security to get and set keychain objects)</string>
 			<key>label</key>
 			<string>Bitwarden CLI Path</string>
 			<key>type</key>
@@ -2310,54 +2310,16 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 			<key>config</key>
 			<dict>
 				<key>default</key>
-				<false/>
-				<key>required</key>
-				<false/>
-				<key>text</key>
-				<string></string>
-			</dict>
-			<key>description</key>
-			<string></string>
-			<key>label</key>
-			<string>Enable Debug Mode (for developers)</string>
-			<key>type</key>
-			<string>checkbox</string>
-			<key>variable</key>
-			<string>DEBUG</string>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>default</key>
-				<false/>
-				<key>required</key>
-				<false/>
-				<key>text</key>
-				<string></string>
-			</dict>
-			<key>description</key>
-			<string></string>
-			<key>label</key>
-			<string>use API key</string>
-			<key>type</key>
-			<string>checkbox</string>
-			<key>variable</key>
-			<string>USE_APIKEY</string>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>default</key>
 				<string>1440</string>
 				<key>placeholder</key>
-				<string>int</string>
+				<string>integer</string>
 				<key>required</key>
 				<false/>
 				<key>trim</key>
 				<true/>
 			</dict>
 			<key>description</key>
-			<string></string>
+			<string>Besides the lock on startup this additional timeout is set to define when Bitwarden should be locked in case of no usage.</string>
 			<key>label</key>
 			<string>auto lock timeout (s)</string>
 			<key>type</key>
@@ -2369,6 +2331,30 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 			<key>config</key>
 			<dict>
 				<key>default</key>
+				<false/>
+				<key>required</key>
+				<false/>
+				<key>text</key>
+				<string></string>
+			</dict>
+			<key>description</key>
+			<string>Since version 2.4.1 the workflow supports login via the api key.
+Get/create an api key via the web ui. See more information here https://bitwarden.com/help/article/cli/#using-an-api-key
+To use the api key login flow in the workflow set the workflow variable USE_APIKEY to true.
+The workflow will then ask you for the client_id and client secret to login.
+Immediately afterwards it will also ask to unlock with the master password to get a session key.
+That is a separate step and required with the api key as login method.</string>
+			<key>label</key>
+			<string>use API key</string>
+			<key>type</key>
+			<string>checkbox</string>
+			<key>variable</key>
+			<string>USE_APIKEY</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
 				<string></string>
 				<key>placeholder</key>
 				<string></string>
@@ -2378,7 +2364,7 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 				<true/>
 			</dict>
 			<key>description</key>
-			<string></string>
+			<string>Set the server url if you host your own Bitwarden instance - you can also set separate domains for api,webvault etc e.g. --api http://localhost:4000 --identity http://localhost:33656</string>
 			<key>label</key>
 			<string>self host url (if you are using official bitwarden, ignore this)</string>
 			<key>type</key>
@@ -2399,7 +2385,7 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 				<true/>
 			</dict>
 			<key>description</key>
-			<string></string>
+			<string>Set the Web UI vault url if you host your own Bitwarden instance - you can also set separate domains for api,webvault etc e.g. --api http://localhost:4000 --identity http://localhost:33656</string>
 			<key>label</key>
 			<string>web UI url</string>
 			<key>type</key>
@@ -2439,7 +2425,7 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 				<string></string>
 			</dict>
 			<key>description</key>
-			<string></string>
+			<string>enables or disables 2FA for login (can be set via .bwconfig )</string>
 			<key>label</key>
 			<string>Enable 2FA</string>
 			<key>type</key>
@@ -2477,13 +2463,32 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 				</array>
 			</dict>
 			<key>description</key>
-			<string>This option is only used when Enable 2FA is checked</string>
+			<string>sets the mode for the 2FA (this option is only used when Enable 2FA is checked, can also be set via .bwconfig )</string>
 			<key>label</key>
 			<string>2FA Mode</string>
 			<key>type</key>
 			<string>popupbutton</string>
 			<key>variable</key>
 			<string>2FA_MODE</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<false/>
+				<key>required</key>
+				<false/>
+				<key>text</key>
+				<string></string>
+			</dict>
+			<key>description</key>
+			<string>If enabled print additional debug information, specially about for the decryption process</string>
+			<key>label</key>
+			<string>Enable Debug Mode (for developers)</string>
+			<key>type</key>
+			<string>checkbox</string>
+			<key>variable</key>
+			<string>DEBUG</string>
 		</dict>
 	</array>
 	<key>variables</key>

--- a/workflow/info.plist
+++ b/workflow/info.plist
@@ -2144,14 +2144,14 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 				<key>default</key>
 				<string></string>
 				<key>placeholder</key>
-				<string>example@provider.com</string>
+				<string>will be read from the data.json of the Bitwarden CLI if present</string>
 				<key>required</key>
 				<false/>
 				<key>trim</key>
 				<true/>
 			</dict>
 			<key>description</key>
-			<string>the email which to use for the login via the Bitwarden CLI, will be read from the data.json of the Bitwarden CLI if present</string>
+			<string>the email which to use for the login via the Bitwarden CLI</string>
 			<key>label</key>
 			<string>bitwarden login email</string>
 			<key>type</key>
@@ -2172,7 +2172,7 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 				<true/>
 			</dict>
 			<key>description</key>
-			<string>defines the keyword which opens the Bitwarden Alfred Workflow</string>
+			<string>the keyword opens the search</string>
 			<key>label</key>
 			<string>Search Keyword</string>
 			<key>type</key>
@@ -2193,7 +2193,7 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 				<true/>
 			</dict>
 			<key>description</key>
-			<string>defines the keyword which opens the folder search of the Bitwarden Alfred Workflow</string>
+			<string>the keyword opens the folder search</string>
 			<key>label</key>
 			<string>Folder Search Keyword</string>
 			<key>type</key>
@@ -2214,7 +2214,7 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 				<true/>
 			</dict>
 			<key>description</key>
-			<string>defines the keyword which opens the Bitwarden authentications of the Alfred Workflow</string>
+			<string>the keyword opens the authentication settings</string>
 			<key>label</key>
 			<string>Authentication Setup Keyword</string>
 			<key>type</key>
@@ -2235,7 +2235,7 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 				<true/>
 			</dict>
 			<key>description</key>
-			<string>defines the keyword which opens the Bitwarden configuration/settings of the Alfred Workflow</string>
+			<string>the keyword opens the configuration/settings</string>
 			<key>label</key>
 			<string>Config Menu Keyword</string>
 			<key>type</key>
@@ -2256,7 +2256,7 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 				<true/>
 			</dict>
 			<key>description</key>
-			<string>defines the keyword which opens the Bitwarden background sync agent</string>
+			<string>the keyword opens the background sync agent settings</string>
 			<key>label</key>
 			<string>Automatic Sync Service Keyword</string>
 			<key>type</key>
@@ -2277,7 +2277,7 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 				<true/>
 			</dict>
 			<key>description</key>
-			<string>defines the keyword which opens the Bitwarden background lock agent</string>
+			<string>the keyword opens the background lock agent settings</string>
 			<key>label</key>
 			<string>Automatic Lock Service Keyword</string>
 			<key>type</key>
@@ -2298,7 +2298,7 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 				<true/>
 			</dict>
 			<key>description</key>
-			<string>The PATH env variable which is used to search for executables (like the Bitwarden CLI configured with BW_EXEC, security to get and set keychain objects)</string>
+			<string>The PATH env variable which is used to search for executables</string>
 			<key>label</key>
 			<string>Bitwarden CLI Path</string>
 			<key>type</key>
@@ -2319,9 +2319,9 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 				<true/>
 			</dict>
 			<key>description</key>
-			<string>Besides the lock on startup this additional timeout is set to define when Bitwarden should be locked in case of no usage.</string>
+			<string></string>
 			<key>label</key>
-			<string>auto lock timeout (s)</string>
+			<string>inactivity lock timeout (s)</string>
 			<key>type</key>
 			<string>textfield</string>
 			<key>variable</key>
@@ -2338,14 +2338,9 @@ Caching of the secret/item names (not the secret values itself) are cached so th
 				<string></string>
 			</dict>
 			<key>description</key>
-			<string>Since version 2.4.1 the workflow supports login via the api key.
-Get/create an api key via the web ui. See more information here https://bitwarden.com/help/article/cli/#using-an-api-key
-To use the api key login flow in the workflow set the workflow variable USE_APIKEY to true.
-The workflow will then ask you for the client_id and client secret to login.
-Immediately afterwards it will also ask to unlock with the master password to get a session key.
-That is a separate step and required with the api key as login method.</string>
+			<string>see more information in README.md</string>
 			<key>label</key>
-			<string>use API key</string>
+			<string>use API key (Optional)</string>
 			<key>type</key>
 			<string>checkbox</string>
 			<key>variable</key>
@@ -2364,7 +2359,7 @@ That is a separate step and required with the api key as login method.</string>
 				<true/>
 			</dict>
 			<key>description</key>
-			<string>Set the server url if you host your own Bitwarden instance - you can also set separate domains for api,webvault etc e.g. --api http://localhost:4000 --identity http://localhost:33656</string>
+			<string>Set the server url if you host your own Bitwarden instance.</string>
 			<key>label</key>
 			<string>self host url (if you are using official bitwarden, ignore this)</string>
 			<key>type</key>
@@ -2385,7 +2380,7 @@ That is a separate step and required with the api key as login method.</string>
 				<true/>
 			</dict>
 			<key>description</key>
-			<string>Set the Web UI vault url if you host your own Bitwarden instance - you can also set separate domains for api,webvault etc e.g. --api http://localhost:4000 --identity http://localhost:33656</string>
+			<string>Set the Web UI vault url if you host your own Bitwarden instance.</string>
 			<key>label</key>
 			<string>web UI url</string>
 			<key>type</key>
@@ -2425,7 +2420,7 @@ That is a separate step and required with the api key as login method.</string>
 				<string></string>
 			</dict>
 			<key>description</key>
-			<string>enables or disables 2FA for login (can be set via .bwconfig )</string>
+			<string>enables or disables 2FA for login</string>
 			<key>label</key>
 			<string>Enable 2FA</string>
 			<key>type</key>
@@ -2463,7 +2458,7 @@ That is a separate step and required with the api key as login method.</string>
 				</array>
 			</dict>
 			<key>description</key>
-			<string>sets the mode for the 2FA (this option is only used when Enable 2FA is checked, can also be set via .bwconfig )</string>
+			<string>sets the mode for the 2FA (this option is only used when Enable 2FA is checked)</string>
 			<key>label</key>
 			<string>2FA Mode</string>
 			<key>type</key>


### PR DESCRIPTION
# List of migrated env vars
```xml
<string>EMAIL</string>
<string>bw_keyword</string>
<string>bwf_keyword</string>
<string>bwauth_keyword</string>
<string>bwconf_keyword</string>
<string>bwauto_keyword</string>
<string>bwautolock_keyword</string>
<string>PATH</string>
<string>LOCK_TIMEOUT</string>
<string>USE_APIKEY</string>
<string>SERVER_URL</string>
<string>WEBUI_URL</string>
<string>SYNC_CACHE_AGE</string>
<string>2FA_ENABLED</string>
<string>2FA_MODE</string>
<string>DEBUG</string>
```

- I only migrated some of the vars that I feel every user would need. descriptions are distilled from README.md. 

# What else changed?
- commit messages should be self-explanatory. 

# migrated configuration in Alfred 5
- should look like something below
![Screenshot 2023-06-10 at 13 26 55](https://github.com/blacs30/bitwarden-alfred-workflow/assets/23202735/77f8a292-2372-4272-a1ef-1284aec60771)
![Screenshot 2023-06-10 at 13 32 25](https://github.com/blacs30/bitwarden-alfred-workflow/assets/23202735/441949ec-6f8d-4e64-a755-23d515b471f2)


- Also the [project](https://github.com/users/zhongjis/projects/1/views/1) page is updated with something I found during the refactor.

# Breaking Change
- based on [this post](https://www.alfredapp.com/help/workflows/user-configuration/), user configuration is not supported before Alfred 5, @blacs30 it is up to you how we want to manage these changes.