### PR TITLE
bash scripts update for workflow V3

### DIFF
--- a/workflow/bw_auto_lock.sh
+++ b/workflow/bw_auto_lock.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
+# this version is targeted at Alfred 5.1.2 and BitwardenV2 3.0.2 or higher
 
 _end() {
-	local r m
-	r=$1
-	m="$2"
-	echo "result|$r|$m"
-	exit $r
+  local r m
+  r=$1
+  m="$2"
+  echo "result|$r|$m"
+  exit $r
 }
 
 _writeplist() {
@@ -15,16 +16,16 @@ _writeplist() {
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Label</key>
-	<string>$launchd_name</string>
-	<key>ProgramArguments</key>
-	<array>
-		<string>/bin/bash</string>
-		<string>--</string>
-		<string>$wf_dir/${0##*/}</string>
-		<string>$LOCK_TIMEOUT</string>
-	</array>
-	<key>RunAtLoad</key>
+  <key>Label</key>
+  <string>$launchd_name</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>--</string>
+    <string>$wf_dir/${0##*/}</string>
+    <string>$LOCK_TIMEOUT</string>
+  </array>
+  <key>RunAtLoad</key>
   <true/>
   <key>StartInterval</key>
   <integer>300</integer>
@@ -33,101 +34,102 @@ _writeplist() {
 EOF
 }
 
-re='^[0-9]+$'
 _install_service() {
   if ! [[ $LOCK_TIMEOUT =~ $re ]]; then
-  	_end 1 "error: LOCK_TIMEOUT must be a number"
+    _end 1 "error: LOCK_TIMEOUT must be a number"
   fi
-
-	_remove_service
-	echo "generating new service configuration"
-	_writeplist
-	if ! /usr/bin/plutil -lint "${plist_tmp_path}"; then _end 1 "did not generate a valid plist"; fi
-	if ! /bin/cp -f "${plist_tmp_path}" "${plist_path}"; then _end 1 "failed to copy LaunchAgent"; fi
-	echo "loading service"
-	/bin/launchctl bootstrap gui/$(id -u) "${plist_path}"
-	if [ $? -eq 0 ]; then
-		_end 0 "Service has been installed; autolock will lock after ${LOCK_TIMEOUT} minutes of inactivity"
-	else
-		_end 1 "Could not install service, check logfiles for detail"
-	fi
+  _remove_service
+  echo "generating new service configuration"
+  _writeplist
+  if ! /usr/bin/plutil -lint "${plist_tmp_path}"; then _end 1 "did not generate a valid plist"; fi
+  if ! /bin/cp -f "${plist_tmp_path}" "${plist_path}"; then _end 1 "failed to copy LaunchAgent"; fi
+  echo "loading service"
+  /bin/launchctl bootstrap gui/$UID "${plist_path}"
+  if [ $? -eq 0 ]; then
+    _end 0 "Service has been installed; autolock will lock after ${LOCK_TIMEOUT} minutes of inactivity"
+  else
+    _end 1 "Could not install service, check logfiles for detail"
+  fi
 }
 
 _remove_service() {
-	echo "removing existing service"
-	/bin/launchctl bootout gui/$(id -u) "${plist_path}" 2>/dev/null
-	/bin/rm "${plist_path}" 2>/dev/null
-	if [ -e "${plist_path}" ]; then
-		_end 1 "Could not delete existing LaunchAgent"
-	else
-		return 0
-	fi
+  echo "removing existing service"
+  /bin/launchctl bootout gui/$UID "${plist_path}" 2>/dev/null
+  /bin/rm "${plist_path}" 2>/dev/null
+  if [ -e "${plist_path}" ]; then
+    _end 1 "Could not delete existing LaunchAgent"
+  else
+    return 0
+  fi
 }
 
 _get_var_from_plist() {
-	# 1=filename, 2=key
-	[ -n "$2" ] || return 1
-	[ -e "$1" ] || return 1
-	/usr/bin/plutil -extract "$2" xml1 -o - -- "$1" |
-	/usr/bin/sed -n "s/.*<string>\(.*\)<\/string>.*/\1/p"
+  # 1=filename, 2=key
+  [ -n "$2" ] || return 1
+  [ -e "$1" ] || return 1
+  /usr/bin/plutil -extract "$2" xml1 -o - -- "$1" |
+  /usr/bin/sed -n "s/.*<string>\(.*\)<\/string>.*/\1/p"
 }
 
 # find TMP dir
 if [ -z "${TMPDIR}" ]; then
-	TMPDIR=$(/usr/bin/getconf DARWIN_USER_TEMP_DIR)
-	if [ ! -e "${TMPDIR}" ]; then
-		_end 1 "could not find TMPDIR directory"
-	fi
+  TMPDIR=$(/usr/bin/getconf DARWIN_USER_TEMP_DIR)
+  if [ ! -e "${TMPDIR}" ]; then
+    _end 1 "could not find TMPDIR directory"
+  fi
 fi
 
-
-
+re='^[0-9]+$'
 prefs="$HOME/Library/Application Support/Alfred/prefs.json"
 [ -e "${prefs}" ] || { echo "can't find Alfred prefs"; exit 1; }
 wf_basedir=$(_get_var_from_plist "${prefs}" current)/workflows
 [ -e "${wf_basedir}" ] || { echo "can't find Alfred workflow dir"; exit 1; }
 
-alfred_app_bundleid=com.runningwithcrayons.Alfred
-export alfred_workflow_bundleid=com.lisowski-development.alfred.bitwarden
-export alfred_workflow_cache="$HOME/Library/Caches/${alfred_app_bundleid}/Workflow Data/${alfred_workflow_bundleid}"
-export alfred_workflow_data="$HOME/Library/Application Support/Alfred/Workflow Data/${alfred_workflow_bundleid}"
+alfred_app_bundleid='com.runningwithcrayons.Alfred'
+alfred_workflow_bundleid='com.lisowski-development.alfred.bitwarden'
+alfred_workflow_cache="$HOME/Library/Caches/${alfred_app_bundleid}/Workflow Data/${alfred_workflow_bundleid}"
+alfred_workflow_data="$HOME/Library/Application Support/Alfred/Workflow Data/${alfred_workflow_bundleid}"
 launchd_name=${alfred_workflow_bundleid}_lock
 plist_path="$HOME/Library/LaunchAgents/${0##*/}_lock_agent.plist"
 plist_tmp_path="$TMPDIR/${launchd_name}.plist"
 
-
-infoplist=$(/usr/bin/find "${wf_basedir}" -name info.plist -depth 2 -exec /usr/bin/grep -H "<string>${alfred_workflow_bundleid}</string>" {} \; | /usr/bin/awk -F: '{ print $1 }')
+infoplist=$(/usr/bin/find -L "${wf_basedir}" -name info.plist -depth 2 -exec /usr/bin/grep -H "<string>${alfred_workflow_bundleid}</string>" {} \; | /usr/bin/awk -F: '{ print $1 }')
 [ -e "${infoplist}" ] || { echo "can't find Bitwarden v2 workflow"; exit 1; }
 wf_dir=${infoplist%/*}
+wf_bin="${wf_dir}/bitwarden-alfred-workflow"
+prefsplist="${wf_dir}/prefs.plist"
 alfred_workflow_version=$(_get_var_from_plist "${infoplist}" version)
 [ -n "${alfred_workflow_version}" ] || { echo "can't determine workflow version"; exit 1; }
-echo "found workflow v${alfred_workflow_version} at ${wf_dir}"
-export alfred_workflow_version
-bwpath=$(_get_var_from_plist "${infoplist}" variables.PATH)
-[ -n "${bwpath}" ] || { echo "PATH variable not set in workflow"; exit 1; }
-export PATH=${bwpath}
-bwexec=$(_get_var_from_plist "${infoplist}" variables.BW_EXEC)
+echo "found workflow v${alfred_workflow_version} at ${wf_dir}" 1>&2
+WF_PATH=$(_get_var_from_plist "${prefsplist}" PATH)
+[ -n "${WF_PATH}" ] || { echo "Bitwarden CLI Path not set in workflow configuration"; exit 1; }
+BW_EXEC=$(_get_var_from_plist "${infoplist}" variables.BW_EXEC)
 if ! hash "${bwexec}" 2>/dev/null; then
-	echo "bw command not found, check PATH env variable"; exit 1;
+  echo "bw command not found, check PATH env variable"; exit 1;
 fi
-export BW_EXEC=${bwexec}
 
-wf_bin="${wf_dir}/bitwarden-alfred-workflow"
+export alfred_workflow_bundleid
+export alfred_workflow_cache
+export alfred_workflow_data
+export alfred_workflow_version
+export PATH=${WF_PATH}
+export BW_EXEC
 
 case $1 in
-	(-i|--install)
-		_install_service
-		exit
-		;;
-	(-r|--remove)
-		_remove_service
-		[ $? -eq 0 ] && _end 0 "Autolock service has been removed"
-		exit
-		;;
+  -i|--install)
+    _install_service
+    exit
+    ;;
+  -r|--remove)
+    if _remove_service; then
+      _end 0 "Autolock service has been removed"
+    fi
+    exit
+    ;;
 esac
 
-# to lock bitwarden directly after start of the system we check the uptime
-# if the system has just started within the last 10 minutes then lock bitwarden
+# to lock Bitwarden directly after start of the system we check the uptime
+# if the system has started within the last 10 minutes then lock Bitwarden
 uptime_string=$(/usr/sbin/sysctl -n kern.boottime | /usr/bin/awk '{print $4}' | /usr/bin/sed 's/,//')
 now=$(/bin/date +%s)
 if [ "$((now-uptime_string))" -lt 300 ]; then
@@ -137,10 +139,9 @@ fi
 
 if [[ $1 =~ $re ]] && [[ -f "${alfred_workflow_cache}"/last-usage ]]; then
   last_usage=$(/bin/cat "${alfred_workflow_cache}"/last-usage)
-	now=$(/bin/date +%s)
-	if [ "$((now-last_usage))" -gt $(($1*60)) ]; then
+  now=$(/bin/date +%s)
+  if [ "$((now-last_usage))" -gt $(($1*60)) ]; then
     /usr/bin/xattr -d com.apple.quarantine "$wf_bin" 2>/dev/null
     "$wf_bin" -lock
   fi
-
 fi

--- a/workflow/bw_cache_update.sh
+++ b/workflow/bw_cache_update.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# this version is targeted at Alfred 5.1.2 and BitwardenV2 3.0.2 or higher
+
 _usage() {
 cat <<EOF
 usage: ${0##*/} [-irlv]
@@ -159,20 +161,19 @@ _setEnvVars() {
   infoplist=$(/usr/bin/find -L "${wf_basedir}" -name info.plist -depth 2 -exec /usr/bin/grep -H "<string>${alfred_workflow_bundleid}</string>" {} \; | /usr/bin/awk -F: '{ print $1 }')
   [ -e "${infoplist}" ] || _end 1 "can't find Bitwarden v2 workflow"
   wf_dir=${infoplist%/*}
+  prefsplist="${wf_dir}/prefs.plist"
   wf_bin="${wf_dir}/bitwarden-alfred-workflow"
   alfred_workflow_version=$(_get_var_from_plist "${infoplist}" version)
   [ -n "${alfred_workflow_version}" ] || _end 1 "can't determine workflow version"
   echo "found workflow v${alfred_workflow_version} at ${wf_dir}" 1>&2
-  WF_PATH=$(_get_var_from_plist "${infoplist}" variables.PATH)
-  [ -n "${WF_PATH}" ] || _end 1 "PATH variable not set in workflow"
+  WF_PATH=$(_get_var_from_plist "${prefsplist}" PATH)
+  [ -n "${WF_PATH}" ] || _end 1 "Bitwarden CLI Path not set in workflow configuration"
   BW_EXEC=$(_get_var_from_plist "${infoplist}" variables.BW_EXEC)
-  bwauth_keyword=$(_get_var_from_plist "${infoplist}" variables.bwauth_keyword)
 
   export alfred_workflow_bundleid
   export alfred_workflow_cache
   export alfred_workflow_data
   export alfred_workflow_version
-  export bwauth_keyword
   export PATH=${WF_PATH}
   export BW_EXEC
   export DEBUG
@@ -202,7 +203,7 @@ case $1 in
     exit
     ;;
   -v|--setenv)
-    if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    if [[ ${BASH_SOURCE[0]} == "${0}" ]]; then
       echo "You must source the script when using this option: \`. ${0##*/} -v\`"
       exit 1
     fi

--- a/workflow/fix_flags.sh
+++ b/workflow/fix_flags.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+read -r 2>/dev/null WF_VER <fix_flags_sentinel
+[[ $alfred_workflow_version == "$WF_VER" ]] && exit
 cd "$(dirname "$0")" || exit 1
 /usr/bin/xattr -d com.apple.quarantine bitwarden-alfred-workflow 2>/dev/null
-/bin/chmod +x bitwarden-alfred-workflow 2>/dev/null
+/bin/chmod +x bitwarden-alfred-workflow bw_auto_lock.sh bw_cache_update.sh 2>/dev/null
+if [[ -n $alfred_workflow_version ]]; then
+  echo "$alfred_workflow_version" >fix_flags_sentinel
+fi

--- a/workflow/info.plist
+++ b/workflow/info.plist
@@ -1480,7 +1480,7 @@
 				<key>fixedorder</key>
 				<true/>
 				<key>items</key>
-				<string>[{"imagefile":"9febae04e9b11418d8c716fa6a295abfcdf2c95b.png","title":"Install","arg":"--install","subtitle":"Install automatic sync service (hour: {var:AUTO_HOUR} min: {var:AUTO_MIN})"},{"imagefile":"21dcb3fb3a76f001daa8d67a857cfb9573060b9a.png","title":"Remove","arg":"--remove","subtitle":"Remove automatic sync service"},{"imagefile":"adde5abb26a131f20cc3417c4206bd81e5341c81.png","title":"Create symlink","arg":"--link","subtitle":"Create symlink to make it easier to trigger a manual sync ({var:AUTOSYNC_SCRIPT_DIR})"}]</string>
+				<string>[{"imagefile":"9febae04e9b11418d8c716fa6a295abfcdf2c95b.png","title":"Install","arg":"--install","subtitle":"Install automatic sync service ({var:AUTOSYNC_TIMES})"},{"imagefile":"21dcb3fb3a76f001daa8d67a857cfb9573060b9a.png","title":"Remove","arg":"--remove","subtitle":"Remove automatic sync service"},{"imagefile":"adde5abb26a131f20cc3417c4206bd81e5341c81.png","title":"Create symlink","arg":"--link","subtitle":"Create symlink to make it easier to trigger a manual sync ({var:AUTOSYNC_SCRIPT_DIR})"}]</string>
 				<key>keyword</key>
 				<string>{var:bwauto_keyword}</string>
 				<key>matchmode</key>


### PR DESCRIPTION
changes related to #175 

- auto-fix +x flag on helper scripts
- add sentinel so fix_flags only runs once per workflow version (slightly faster)
- fixed subtitle description during agent install (`{var:AUTO_HOUR}` & `{var:AUTO_MIN}` -> `{var:AUTOSYNC_TIMES}`)
- minor updates to script formatting & syntax
- update to be compatible with new workflow config e.g. `PATH`

